### PR TITLE
Relax cppzmq dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ message(STATUS "xwidgets binary version: v${XWIDGETS_BINARY_VERSION}")
 # Dependencies
 # ============
 
-find_package(cppzmq 4.3.0 REQUIRED)
 find_package(xtl 0.6.5 REQUIRED)
 find_package(xeus 0.21.1 REQUIRED)
 find_package(xproperty 0.10.0 REQUIRED)


### PR DESCRIPTION
We were running `find_package(cppzmq)` while not really using the target in the cmake. Removing that line.