### PR TITLE
fix to #191 by templatizing lambda

### DIFF
--- a/include/xwidgets/xeither.hpp
+++ b/include/xwidgets/xeither.hpp
@@ -12,30 +12,30 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
-
 #include "xtl/xoptional.hpp"
 
-#define XEITHER(...)                                                         \
-    [](const auto& proposal) {                                               \
-        static const std::unordered_set<std::string> options({__VA_ARGS__}); \
-        auto position = options.find(proposal);                              \
-        if (position == options.end())                                       \
-        {                                                                    \
-            throw std::runtime_error("Invalid proposal for string enum");    \
-        }                                                                    \
-    }
+template <typename ... T>
+auto XEITHER(T... vals)	{			\
+  const std::unordered_set<std::string> options({vals...});
+  return [options](const auto& proposal) {
+	   auto position = options.find(proposal);
+	   if (position == options.end()) {
+            throw std::runtime_error("Invalid proposal for string enum");
+	   }					\
+	 };
+}
 
-#define XEITHER_OPTIONAL(...)                                                          \
-    [](const auto& proposal) {                                                         \
-        if (xtl::has_value(proposal))                                                  \
-        {                                                                              \
-            static const std::unordered_set<std::string> options({__VA_ARGS__});       \
-            auto position = options.find(xtl::value(proposal));                        \
-            if (position == options.end())                                             \
-            {                                                                          \
-                throw std::runtime_error("Invalid proposal for optional string enum"); \
-            }                                                                          \
-        }                                                                              \
-    }
+template <typename ... T>
+auto XEITHER_OPTIONAL(T...vals) {
+    const std::unordered_set<std::string> options({vals...});
+    return [options](const auto& proposal) {
+	     if (xtl::has_value(proposal)) {
+	       auto position = options.find(xtl::value(proposal));
+	       if (position == options.end()) {
+		 throw std::runtime_error("Invalid proposal for optional string enum");
+	       }
+	     }
+	   };
+}
 
 #endif


### PR DESCRIPTION
This fixes #191 crash by using templates and parameter packs rather
than using the preprocessor to process xeither.