### PR TITLE
Refactor xtransport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set(XWIDGETS_HEADERS
     ${XWIDGETS_INCLUDE_DIR}/xwidgets/xcheckbox.hpp
     ${XWIDGETS_INCLUDE_DIR}/xwidgets/xcolor.hpp
     ${XWIDGETS_INCLUDE_DIR}/xwidgets/xcolor_picker.hpp
+    ${XWIDGETS_INCLUDE_DIR}/xwidgets/xcommon.hpp
     ${XWIDGETS_INCLUDE_DIR}/xwidgets/xcontroller.hpp
     ${XWIDGETS_INCLUDE_DIR}/xwidgets/xdropdown.hpp
     ${XWIDGETS_INCLUDE_DIR}/xwidgets/xeither.hpp
@@ -126,6 +127,7 @@ set(XWIDGETS_SOURCES
     ${XWIDGETS_SOURCE_DIR}/xcheckbox.cpp
     ${XWIDGETS_SOURCE_DIR}/xcolor_picker.cpp
     ${XWIDGETS_SOURCE_DIR}/xcontroller.cpp
+    ${XWIDGETS_SOURCE_DIR}/xcommon.cpp
     ${XWIDGETS_SOURCE_DIR}/xdropdown.cpp
     ${XWIDGETS_SOURCE_DIR}/xhtml.cpp
     ${XWIDGETS_SOURCE_DIR}/ximage.cpp

--- a/include/xwidgets/xcommon.hpp
+++ b/include/xwidgets/xcommon.hpp
@@ -1,0 +1,134 @@
+/***************************************************************************
+* Copyright (c) 2017, Sylvain Corlay and Johan Mabille                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XWIDGETS_COMMON_HPP
+#define XWIDGETS_COMMON_HPP
+
+#include <string>
+#include <vector>
+
+#include "xeus/xcomm.hpp"
+
+#include "xbinary.hpp"
+#include "xcommon.hpp"
+#include "xholder.hpp"
+#include "xtarget.hpp"
+#include "xwidgets_config.hpp"
+
+namespace xw
+{
+    /**********************************************
+     * property serialization and deserialization *
+     **********************************************/
+
+    // Values
+
+    template <class T>
+    inline void xwidgets_serialize(const T& value, nl::json& j, xeus::buffer_sequence&)
+    {
+        j = value;
+    }
+
+    template <class T>
+    inline void xwidgets_deserialize(T& value, const nl::json& j, const xeus::buffer_sequence&)
+    {
+        value = j.template get<T>();
+    }
+
+    /***********************
+     * xcommon declaration *
+     ***********************/
+
+    class XWIDGETS_API xcommon
+    {
+    public:
+
+        xeus::xguid id() const noexcept;
+        void display() const;
+
+    protected:
+
+        xcommon();
+        xcommon(xeus::xcomm&&);
+        ~xcommon();
+        xcommon(const xcommon&);
+        xcommon(xcommon&&);
+        xcommon& operator=(const xcommon&);
+        xcommon& operator=(xcommon&&);
+
+        bool moved_from() const noexcept;
+        void handle_custom_message(const nl::json&);
+        xeus::xcomm& comm();
+        const xeus::xcomm& comm() const;
+        const xeus::xmessage*& hold();
+        const xeus::xmessage* const& hold() const;
+        const std::vector<xjson_path_type>& buffer_paths() const;
+
+        void open(nl::json&& patch, xeus::buffer_sequence&& buffers);
+        void close();
+
+        template <class T>
+        void notify(const std::string& name, const T& value) const;
+        void send(nl::json&&, xeus::buffer_sequence&&) const;
+        void send_patch(nl::json&&, xeus::buffer_sequence&&) const;
+
+    private:
+
+        bool same_patch(const std::string&,
+                        const nl::json&,
+                        const xeus::buffer_sequence&,
+                        const nl::json&,
+                        const xeus::buffer_sequence&) const;
+
+        bool m_moved_from;
+        const xeus::xmessage* m_hold;
+        xeus::xcomm m_comm;
+        std::vector<xjson_path_type> m_buffer_paths;
+    };
+
+    /**************************
+     * to_json specialization *
+     *************************/
+
+    void XWIDGETS_API to_json(nl::json& j, const xcommon& o);
+
+    /********************************************
+     * xcommon template methods implementations *
+     ********************************************/
+
+    template <class T>
+    inline void xcommon::notify(const std::string& name, const T& value) const
+    {
+        nl::json state;
+        xeus::buffer_sequence buffers;
+        xwidgets_serialize(value, state[name], buffers);
+
+        if (m_hold != nullptr)
+        {
+            const auto& hold_state = m_hold->content()["data"]["state"];
+            const auto& hold_buffers = m_hold->buffers();
+
+            auto it = hold_state.find(name);
+            if (it != hold_state.end())
+            {
+                if(same_patch(name,
+                              *it,
+                              hold_buffers,
+                              state[name],
+                              buffers))
+                {
+                    return;
+                }
+            }
+        }
+
+        send_patch(std::move(state), std::move(buffers));
+    }
+}
+
+#endif

--- a/include/xwidgets/xmedia.hpp
+++ b/include/xwidgets/xmedia.hpp
@@ -38,8 +38,6 @@ namespace xw
 
         XPROPERTY(value_type, derived_type, value);
 
-        const std::vector<xjson_path_type>& buffer_paths() const;
-
     protected:
 
         xmedia();
@@ -76,13 +74,6 @@ namespace xw
         base_type::apply_patch(patch, buffers);
 
         set_property_from_patch(value, patch, buffers);
-    }
-
-    template <class D>
-    inline const std::vector<xjson_path_type>& xmedia<D>::buffer_paths() const
-    {
-        static const std::vector<xjson_path_type> default_buffer_paths = {{"value"}};
-        return default_buffer_paths;
     }
 
     template <class D>

--- a/include/xwidgets/xobject.hpp
+++ b/include/xwidgets/xobject.hpp
@@ -21,9 +21,9 @@
 
 namespace xw
 {
-    /****************************
-     * base xobject declaration *
-     ****************************/
+    /***********************
+     * xobject declaration *
+     ***********************/
 
     template <class D>
     class xobject : public xp::xobserved<D>, public xtransport<D>
@@ -59,9 +59,9 @@ namespace xw
 #endif
     };
 
-    /*******************************
-     * base xobject implementation *
-     *******************************/
+    /**************************
+     * xobject implementation *
+     **************************/
 
     template <class D>
     inline void xobject<D>::serialize_state(nl::json& state, xeus::buffer_sequence& buffers) const

--- a/include/xwidgets/xtransport.hpp
+++ b/include/xwidgets/xtransport.hpp
@@ -17,30 +17,13 @@
 #include "xeus/xinterpreter.hpp"
 
 #include "xbinary.hpp"
+#include "xcommon.hpp"
 #include "xholder.hpp"
 #include "xtarget.hpp"
 #include "xwidgets_config.hpp"
 
 namespace xw
 {
-    /**********************************************
-     * property serialization and deserialization *
-     **********************************************/
-
-    // Values
-
-    template <class T>
-    inline void xwidgets_serialize(const T& value, nl::json& j, xeus::buffer_sequence&)
-    {
-        j = value;
-    }
-
-    template <class T>
-    inline void xwidgets_deserialize(T& value, const nl::json& j, const xeus::buffer_sequence&)
-    {
-        value = j.template get<T>();
-    }
-
     // Properties
 
     template <class P>
@@ -55,28 +38,21 @@ namespace xw
         }
     }
 
-    /*******************************
-     * base xtransport declaration *
-     *******************************/
+    /**************************
+     * xtransport declaration *
+     **************************/
 
     template <class D>
-    class xtransport
+    class xtransport : public xcommon
     {
     public:
 
+        using base_type = xcommon;
         using derived_type = D;
 
         derived_type& derived_cast() & noexcept;
         const derived_type& derived_cast() const & noexcept;
         derived_type derived_cast() && noexcept;
-
-        xeus::xguid id() const noexcept;
-        void display() const;
-
-        void send_patch(nl::json&&, xeus::buffer_sequence&&) const;
-        void send(nl::json&&, xeus::buffer_sequence&&) const;
-
-        const std::vector<xjson_path_type>& buffer_paths() const;
 
     protected:
 
@@ -88,27 +64,12 @@ namespace xw
         xtransport& operator=(const xtransport&);
         xtransport& operator=(xtransport&&);
 
-        bool moved_from() const noexcept;
         void open();
         void close();
-
-        template <class T>
-        void notify(const std::string& name, const T& value) const;
 
     private:
 
         void handle_message(const xeus::xmessage&);
-        void handle_custom_message(const nl::json&);
-
-        bool same_patch(const std::string&,
-                        const nl::json&,
-                        const xeus::buffer_sequence&,
-                        const nl::json&,
-                        const xeus::buffer_sequence&) const;
-
-        bool m_moved_from;
-        const xeus::xmessage* m_hold;
-        xeus::xcomm m_comm;
     };
 
     template <class T, class R = void>
@@ -125,29 +86,24 @@ namespace xw
      ****************************************/
 
     template <class D>
-    void to_json(nl::json& j, const xtransport<D>& o);
-
-    template <class D>
     void from_json(const nl::json& j, xtransport<D>& o);
 
-    /**********************************
-     * base xtransport implementation *
-     **********************************/
+    /*****************************
+     * xtransport implementation *
+     *****************************/
 
     template <class D>
     inline xtransport<D>::xtransport()
-        : m_moved_from(false),
-          m_hold(nullptr),
-          m_comm(get_widget_target(), xeus::new_xguid())
+        : base_type()
     {
-        m_comm.on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
+        this->comm().on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
         get_transport_registry().register_weak(this);
     }
 
     template <class D>
     inline xtransport<D>::~xtransport()
     {
-        if (!m_moved_from)
+        if (!this->moved_from())
         {
             get_transport_registry().unregister(this->id());
         }
@@ -155,11 +111,9 @@ namespace xw
 
     template <class D>
     inline xtransport<D>::xtransport(xeus::xcomm&& comm, bool owning)
-        : m_moved_from(false),
-          m_hold(nullptr),
-          m_comm(std::move(comm))
+        : xcommon(std::move(comm))
     {
-        m_comm.on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
+        this->comm().on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
         if (!owning)
         {
             get_transport_registry().register_weak(this);
@@ -168,33 +122,26 @@ namespace xw
 
     template <class D>
     inline xtransport<D>::xtransport(const xtransport& other)
-        : m_moved_from(false),
-          m_hold(nullptr),
-          m_comm(other.m_comm)
+        : xcommon(other)
     {
-        m_comm.on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
+        this->comm().on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
         get_transport_registry().register_weak(this);
     }
 
     template <class D>
     inline xtransport<D>::xtransport(xtransport&& other)
-        : m_moved_from(false),
-          m_hold(nullptr),
-          m_comm(std::move(other.m_comm))
+        : xcommon(std::move(other))
     {
-        other.m_moved_from = true;
-        m_comm.on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
+        this->comm().on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
         get_transport_registry().register_weak(this);  // Replacing the address of the moved transport with `this`.
     }
 
     template <class D>
     inline xtransport<D>& xtransport<D>::operator=(const xtransport& other)
     {
-        m_moved_from = false;
+        base_type::operator=(other);
         get_transport_registry().unregister(this->id());
-        m_hold = nullptr;
-        m_comm = other.m_comm;
-        m_comm.on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
+        this->comm().on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
         get_transport_registry().register_weak(this);
         return *this;
     }
@@ -202,12 +149,9 @@ namespace xw
     template <class D>
     inline xtransport<D>& xtransport<D>::operator=(xtransport&& other)
     {
-        other.m_moved_from = true;
-        m_moved_from = false;
+        base_type::operator=(std::move(other));
         get_transport_registry().unregister(this->id());
-        m_hold = nullptr;
-        m_comm = std::move(other.m_comm);
-        m_comm.on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
+        this->comm().on_message(std::bind(&xtransport::handle_message, this, std::placeholders::_1));
         get_transport_registry().register_weak(this);  // Replacing the address of the moved transport with `this`.
         return *this;
     }
@@ -231,138 +175,21 @@ namespace xw
     }
 
     template <class D>
-    inline auto xtransport<D>::id() const noexcept -> xeus::xguid
-    {
-        return m_comm.id();
-    }
-
-    template <class D>
-    inline void xtransport<D>::display() const
-    {
-        nl::json mime_bundle;
-
-        // application/vnd.jupyter.widget-view+json
-        nl::json widgets_json;
-        widgets_json["version_major"] = XWIDGETS_PROTOCOL_VERSION_MAJOR;
-        widgets_json["version_minor"] = XWIDGETS_PROTOCOL_VERSION_MINOR;
-        widgets_json["model_id"] = this->id();
-        mime_bundle["application/vnd.jupyter.widget-view+json"] = std::move(widgets_json);
-
-        // text/plain
-        mime_bundle["text/plain"] = "A Jupyter widget";
-
-        ::xeus::get_interpreter().display_data(
-            std::move(mime_bundle),
-            nl::json::object(),
-            nl::json::object());
-    }
-
-    template <class D>
-    template <class T>
-    inline void xtransport<D>::notify(const std::string& name, const T& value) const
-    {
-        nl::json state;
-        xeus::buffer_sequence buffers;
-        xwidgets_serialize(value, state[name], buffers);
-
-        if (m_hold != nullptr)
-        {
-            const auto& hold_state = m_hold->content()["data"]["state"];
-            const auto& hold_buffers = m_hold->buffers();
-
-            auto it = hold_state.find(name);
-            if (it != hold_state.end())
-            {
-                if(same_patch(name,
-                              *it,
-                              hold_buffers,
-                              state[name],
-                              buffers))
-                {
-                    return;
-                }
-            }
-        }
-
-        send_patch(std::move(state), std::move(buffers));
-    }
-
-    template <class D>
-    inline void xtransport<D>::send_patch(nl::json&& patch, xeus::buffer_sequence&& buffers) const
-    {
-        // extract buffer paths
-        auto paths = nl::json::array();
-        extract_buffer_paths(derived_cast().buffer_paths(), patch, buffers, paths);
-
-        // metadata
-        nl::json metadata;
-        metadata["version"] = XWIDGETS_PROTOCOL_VERSION;
-
-        // data
-        nl::json data;
-        data["method"] = "update";
-        data["state"] = std::move(patch);
-        data["buffer_paths"] = std::move(paths);
-
-        // send
-        m_comm.send(std::move(metadata), std::move(data), std::move(buffers));
-    }
-
-    template <class D>
-    inline void xtransport<D>::send(nl::json&& content, xeus::buffer_sequence&& buffers) const
-    {
-        // metadata
-        nl::json metadata;
-        metadata["version"] = XWIDGETS_PROTOCOL_VERSION;
-
-        // data
-        nl::json data;
-        data["method"] = "custom";
-        data["content"] = std::move(content);
-
-        // send
-        m_comm.send(std::move(metadata), std::move(data), std::move(buffers));
-    }
-
-    template <class D>
-    inline const std::vector<xjson_path_type>& xtransport<D>::buffer_paths() const
-    {
-        static const std::vector<xjson_path_type> default_buffer_paths;
-        return default_buffer_paths;
-    }
-
-    template <class D>
-    inline bool xtransport<D>::moved_from() const noexcept
-    {
-        return m_moved_from;
-    }
-
-    template <class D>
     inline void xtransport<D>::open()
     {
-        // extract buffer paths
-        nl::json paths;
+        // serialize state
         nl::json state;
         xeus::buffer_sequence buffers;
         derived_cast().serialize_state(state, buffers);
-        extract_buffer_paths(derived_cast().buffer_paths(), state, buffers, paths);
 
-        // metadata
-        nl::json metadata;
-        metadata["version"] = XWIDGETS_PROTOCOL_VERSION;
-
-        // data
-        nl::json data;
-        data["state"] = std::move(state);
-        data["buffer_paths"] = std::move(paths);
-
-        m_comm.open(std::move(metadata), std::move(data), std::move(buffers));
+        // open comm
+        base_type::open(std::move(state), std::move(buffers));        
     }
 
     template <class D>
     inline void xtransport<D>::close()
     {
-        m_comm.close(nl::json::object(), nl::json::object(), xeus::buffer_sequence());
+        base_type::close();
     }
 
     template <class D>
@@ -370,22 +197,27 @@ namespace xw
     {
         const nl::json& content = message.content();
         const nl::json& data = content["data"];
-        std::string method = data["method"];
+        const std::string method = data["method"];
+
         if (method == "update")
         {
             const nl::json& state = data["state"];
             const auto& buffers = message.buffers();
             const nl::json& buffer_paths = data["buffer_paths"];
-            m_hold = std::addressof(message);;
+            this->hold() = std::addressof(message);;
             insert_buffer_paths(const_cast<nl::json&>(state), buffer_paths);
+            /*D*/
             derived_cast().apply_patch(state, buffers);
-            m_hold = nullptr;
+            /*D*/
+            this->hold() = nullptr;
         }
         else if (method == "request_state")
         {
             nl::json state;
             xeus::buffer_sequence buffers;
+            /*D*/
             derived_cast().serialize_state(state, buffers);
+            /*D*/
             send_patch(std::move(state), std::move(buffers));
         }
         else if (method == "custom")
@@ -393,55 +225,16 @@ namespace xw
             auto it = data.find("content");
             if (it != data.end())
             {
+                /*D*/
                 derived_cast().handle_custom_message(it.value());
+                /*D*/
             }
         }
     }
 
-    template <class D>
-    inline void xtransport<D>::handle_custom_message(const nl::json& /*content*/)
-    {
-    }
-
-    template <class D>
-    inline bool xtransport<D>::same_patch(const std::string& name,
-                                          const nl::json& j1,
-                                          const xeus::buffer_sequence&,
-                                          const nl::json& j2,
-                                          const xeus::buffer_sequence&) const
-         {
-             const auto& paths = derived_cast().buffer_paths();
-             // For a widget with no binary buffer, compare the patches
-             if (paths.empty())
-             {
-                 return j1 == j2;
-             }
-             else
-             {
-                 // For a property with no binary buffer, compare the patches
-                 if (std::find_if(paths.cbegin(), paths.cend(), [name](const auto& v) {
-                     return !v.empty() && v[0] == name;
-                 }) == paths.cend())
-                 {
-                    return j1 == j2;
-                 }
-                 else
-                 {
-                     // TODO: handle the comparison of binary buffers.
-                     return true;
-                 }
-             }
-         }
-
-    /****************************************
-     * to_json and from_json implementation *
-     ****************************************/
-
-    template <class D>
-    inline void to_json(nl::json& j, const xtransport<D>& o)
-    {
-        j = "IPY_MODEL_" + std::string(o.id());
-    }
+    /****************************
+     * from_json implementation *
+     ****************************/
 
     template <class D>
     inline void from_json(const nl::json& j, xtransport<D>& o)
@@ -449,7 +242,9 @@ namespace xw
         std::string prefixed_guid = j;
         xeus::xguid guid = prefixed_guid.substr(10).c_str();
         auto& holder = get_transport_registry().find(guid);
+        /*D*/
         o.derived_cast() = std::move(holder.template get<D>());
+        /*D*/
     }
 }
 

--- a/include/xwidgets/xwidget.hpp
+++ b/include/xwidgets/xwidget.hpp
@@ -17,9 +17,9 @@
 
 namespace xw
 {
-    /******************************
-     * base xwidgets declarations *
-     ******************************/
+    /*************************
+     * xwidgets declarations *
+     *************************/
 
     template <class D>
     class xwidget : public xobject<D>
@@ -45,9 +45,9 @@ namespace xw
         void set_defaults();
     };
 
-    /********************************
-     * base xwidgets implementation *
-     ********************************/
+    /***************************
+     * xwidgets implementation *
+     ***************************/
 
     template <class D>
     inline xwidget<D>::xwidget()

--- a/src/xcommon.cpp
+++ b/src/xcommon.cpp
@@ -1,0 +1,215 @@
+#include "xwidgets/xcommon.hpp"
+
+#include "xeus/xinterpreter.hpp"
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace xw
+{
+    xcommon::xcommon()
+        : m_moved_from(false),
+          m_hold(nullptr),
+          m_comm(get_widget_target(), xeus::new_xguid())
+    {
+    }
+
+    xcommon::~xcommon()
+    {
+    }
+
+    xcommon::xcommon(xeus::xcomm&& comm)
+        : m_moved_from(false),
+          m_hold(nullptr),
+          m_comm(std::move(comm))
+    {
+    }
+
+    xcommon::xcommon(const xcommon& other)
+        : m_moved_from(false),
+          m_hold(nullptr),
+          m_comm(other.m_comm)
+    {
+    }
+
+    xcommon::xcommon(xcommon&& other)
+        : m_moved_from(false),
+          m_hold(nullptr),
+          m_comm(std::move(other.m_comm))
+    {
+        other.m_moved_from = true;
+    }
+
+    xcommon& xcommon::operator=(const xcommon& other)
+    {
+        m_moved_from = false;
+        m_hold = nullptr;
+        m_comm = other.m_comm;
+        return *this;
+    }
+
+    xcommon& xcommon::operator=(xcommon&& other)
+    {
+        other.m_moved_from = true;
+        m_moved_from = false;
+        m_hold = nullptr;
+        m_comm = std::move(other.m_comm);
+        return *this;
+    }
+
+    auto xcommon::id() const noexcept -> xeus::xguid
+    {
+        return m_comm.id();
+    }
+
+    void xcommon::display() const
+    {
+        nl::json mime_bundle;
+
+        // application/vnd.jupyter.widget-view+json
+        nl::json widgets_json;
+        widgets_json["version_major"] = XWIDGETS_PROTOCOL_VERSION_MAJOR;
+        widgets_json["version_minor"] = XWIDGETS_PROTOCOL_VERSION_MINOR;
+        widgets_json["model_id"] = this->id();
+        mime_bundle["application/vnd.jupyter.widget-view+json"] = std::move(widgets_json);
+
+        // text/plain
+        mime_bundle["text/plain"] = "A Jupyter widget";
+
+        ::xeus::get_interpreter().display_data(
+            std::move(mime_bundle),
+            nl::json::object(),
+            nl::json::object());
+    }
+
+    void xcommon::send(nl::json&& content, xeus::buffer_sequence&& buffers) const
+    {
+        // metadata
+        nl::json metadata;
+        metadata["version"] = XWIDGETS_PROTOCOL_VERSION;
+
+        // data
+        nl::json data;
+        data["method"] = "custom";
+        data["content"] = std::move(content);
+
+        // send
+        m_comm.send(std::move(metadata), std::move(data), std::move(buffers));
+    }
+
+    void xcommon::handle_custom_message(const nl::json& /*content*/)
+    {
+    }
+    
+    xeus::xcomm& xcommon::comm()
+    {
+        return m_comm;
+    }
+
+    const xeus::xcomm& xcommon::comm() const
+    {
+        return m_comm;
+    }
+
+    const xeus::xmessage*& xcommon::hold()
+    {
+        return m_hold;
+    }
+
+    const xeus::xmessage* const& xcommon::hold() const
+    {
+        return m_hold;
+    }
+
+    bool xcommon::moved_from() const noexcept
+    {
+        return m_moved_from;
+    }
+
+    const std::vector<xjson_path_type>& xcommon::buffer_paths() const
+    {
+        return m_buffer_paths;
+    }
+
+    void xcommon::send_patch(nl::json&& patch, xeus::buffer_sequence&& buffers) const
+    {
+        // extract buffer paths
+        auto paths = nl::json::array();
+        extract_buffer_paths(buffer_paths(), patch, buffers, paths);
+
+        // metadata
+        nl::json metadata;
+        metadata["version"] = XWIDGETS_PROTOCOL_VERSION;
+
+        // data
+        nl::json data;
+        data["method"] = "update";
+        data["state"] = std::move(patch);
+        data["buffer_paths"] = std::move(paths);
+
+        // send
+        m_comm.send(std::move(metadata), std::move(data), std::move(buffers));
+    }
+
+    void xcommon::open(nl::json&& patch, xeus::buffer_sequence&& buffers)
+    {
+        // extract buffer paths
+        auto paths = nl::json::array();
+        extract_buffer_paths(buffer_paths(), patch, buffers, paths);
+
+        // metadata
+        nl::json metadata;
+        metadata["version"] = XWIDGETS_PROTOCOL_VERSION;
+
+        // data
+        nl::json data;
+
+        data["state"] = std::move(patch);
+        data["buffer_paths"] = std::move(paths);
+
+        // open
+        m_comm.open(std::move(metadata), std::move(data), std::move(buffers));
+    }
+
+    void xcommon::close()
+    {
+        // close
+        m_comm.close(nl::json::object(), nl::json::object(), xeus::buffer_sequence());
+    } 
+
+    bool xcommon::same_patch(const std::string& name,
+                                    const nl::json& j1,
+                                    const xeus::buffer_sequence&,
+                                    const nl::json& j2,
+                                    const xeus::buffer_sequence&) const
+    {
+        const auto& paths = buffer_paths();
+        // For a widget with no binary buffer, compare the patches
+        if (paths.empty())
+        {
+            return j1 == j2;
+        }
+        else
+        {
+            // For a property with no binary buffer, compare the patches
+            if (std::find_if(paths.cbegin(), paths.cend(), [name](const auto& v) {
+                return !v.empty() && v[0] == name;
+            }) == paths.cend())
+            {
+                return j1 == j2;
+            }
+            else
+            {
+                // TODO: handle the comparison of binary buffers.
+                return true;
+            }
+        }
+    }
+
+    void to_json(nl::json& j, const xcommon& o)
+    {
+        j = "IPY_MODEL_" + std::string(o.id());
+    }
+}


### PR DESCRIPTION
@serge-sans-paille

Binary sizes (both using xproperty master, which already improves thind a lot:):

 - before: 3147264 (2210176 stripped)
 - after: 2771664 (1923400 stripped)