### PR TITLE
Fix cmake build type being always set to Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(xwidgets)
 
-message(STATUS "Forcing tests build type to Release")
-set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-
 set(XWIDGETS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(XWIDGETS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 


### PR DESCRIPTION
I removed two lines from the main `CMakeLists.txt` that always forced the build in Release mode for building the tests even though tests are not enabled.

The same lines can be found in the `test/CMakeLists.txt` file so I think they're just a leftover.