### PR TITLE
added function to add widgets via id and link widgets via holder

### DIFF
--- a/include/xwidgets/xbox.hpp
+++ b/include/xwidgets/xbox.hpp
@@ -44,6 +44,8 @@ namespace xw
         template <class T>
         void add(xtransport<T>&& w);
 
+        void add(const xeus::xguid & id);
+
         template <class T>
         enable_xtransport_t<T> add(std::shared_ptr<T> w);
 
@@ -128,6 +130,17 @@ namespace xw
 
         set_property_from_patch(box_style, patch, buffers);
         set_property_from_patch(children, patch, buffers);
+    }
+
+
+    template <class D>
+    inline void xbox<D>::add(const xeus::xguid & id)
+    {
+        this->children().emplace_back(make_id_holder(id));
+        nl::json state;
+        xeus::buffer_sequence buffers;
+        xwidgets_serialize(children(), state["children"], buffers);
+        this->send_patch(std::move(state), std::move(buffers));
     }
 
     template <class D>

--- a/include/xwidgets/xbox.hpp
+++ b/include/xwidgets/xbox.hpp
@@ -132,7 +132,6 @@ namespace xw
         set_property_from_patch(children, patch, buffers);
     }
 
-
     template <class D>
     inline void xbox<D>::add(const xeus::xguid & id)
     {

--- a/include/xwidgets/xlink.hpp
+++ b/include/xwidgets/xlink.hpp
@@ -43,6 +43,8 @@ namespace xw
 
     protected:
 
+        xlink(const xholder & s, const  std::string & sn, const xholder & t, const  std::string & tn);
+
         template <class S, class T>
         xlink(xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn);
 
@@ -79,6 +81,8 @@ namespace xw
 
     protected:
 
+        xdirectional_link(const xholder & s, const  std::string & sn, const xholder & t, const  std::string & tn);
+
         template <class S, class T>
         xdirectional_link(const xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn);
 
@@ -111,6 +115,17 @@ namespace xw
 
         set_property_from_patch(source, patch, buffers);
         set_property_from_patch(target, patch, buffers);
+    }
+
+    template <class D>
+    inline xlink<D>::xlink(const xholder & s, const  std::string & sn, const xholder & t, const  std::string & tn)
+        : base_type()
+    {
+        set_defaults();
+        std::get<0>(this->source()) = s;
+        std::get<1>(this->source()) = sn;
+        std::get<0>(this->target()) = t;
+        std::get<1>(this->target()) = tn;
     }
 
     template <class D>
@@ -153,6 +168,17 @@ namespace xw
 
         set_property_from_patch(source, patch, buffers);
         set_property_from_patch(target, patch, buffers);
+    }
+
+    template <class D>
+    inline xdirectional_link<D>::xdirectional_link(const xholder & s, const  std::string & sn, const xholder & t, const  std::string & tn)
+        : base_type()
+    {
+        set_defaults();
+        std::get<0>(this->source()) = s;
+        std::get<1>(this->source()) = sn;
+        std::get<0>(this->target()) = t;
+        std::get<1>(this->target()) = tn;
     }
 
     template <class D>


### PR DESCRIPTION
this allows to use xwidgets in conjunction with a dynamic language a la lua.
With that:
 * widgets can be added via id (ie in a typeless fashion) to layouts (ie to xbox or derived classes)
 * xlink / xdirectional_link can be constructed from `xholder`(ie in a typeless fashion)
