### PR TITLE
Remove  JupyterLab extension install from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,6 @@ or JupyterLab.
 mamba install widgetsnbextension -c conda-forge
 ```
 
-- Installing the JupyterLab extension
-
-```
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-```
-
-This command defaults to installing the latest version of the JupyterLab
-extension. Depending on the version of `xwidgets` and `jupyterlab` you have
-installed you may need an older version.
-
 ## Installation from sources
 
 Or you can directly install it from the sources if you have all the


### PR DESCRIPTION
Dear maintainers,

I am experimenting with `xwidgets` with jupyter lab 4.0.8 and xeus-cling 0.15.1 
I successfully installed it following the documentation with
```
mamba install xwidgets -c conda-forge
```
The `README.md` specifies that to use the widgets in jupyterlab it is necessary to install the related extension, but when I run
```
jupyter labextension install @jupyter-widgets/jupyterlab-manager
```
 a deprecation warning and an error are thrown
```
Deprecated) Installing extensions with the jupyter labextension install command is now deprecated and will be removed in a future major version of JupyterLab.

Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages 
/home/cmarmo/.conda/envs/with-mamba/lib/python3.12/site-packages/jupyterlab/debuglog.py:56: UserWarning: An error occurred.
  warnings.warn("An error occurred.")
/home/cmarmo/.conda/envs/with-mamba/lib/python3.12/site-packages/jupyterlab/debuglog.py:57: UserWarning: ValueError: Please install nodejs >=18.0.0 before continuing. nodejs may be installed using conda or directly from the nodejs website.
  warnings.warn(msg[-1].strip())
/home/cmarmo/.conda/envs/with-mamba/lib/python3.12/site-packages/jupyterlab/debuglog.py:58: UserWarning: See the log file for details: /tmp/jupyterlab-debug-b6osrght.log
  warnings.warn(f"See the log file for details: {log_path!s}")
```

BTW nodejs is installed on my system
```
$ node --version
v21.1.0
```

As the widgets work as expected in my jupyterlab instance I guess those instructions are obsolete and in this pull request I have removed them from the `README.md`.

Thanks for your attention and your time in developing xwidgets. 