### PR TITLE
Enable xwidgets with xeus-cpp-lite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,11 @@ macro(xwidgets_create_target target_name linkage output_name)
         OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
         OR CMAKE_CXX_COMPILER_ID MATCHES "Intel"
     )
-        target_compile_options(${target_name} PUBLIC -Wunused-parameter -Wextra -Wreorder)
+        if(EMSCRIPTEN)
+            target_compile_options(${target_name} PRIVATE -fPIC)
+        else()
+            target_compile_options(${target_name} PUBLIC -Wunused-parameter -Wextra -Wreorder)
+        endif()
 
         message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
     endif()

--- a/include/xwidgets/xwidgets_config.hpp
+++ b/include/xwidgets/xwidgets_config.hpp
@@ -106,4 +106,8 @@
 #include "xwidgets_config_cling.hpp"
 #endif
 
+#if defined(__CLANG_REPL__) && defined(__EMSCRIPTEN__)
+#include "xwidgets_config_cling.hpp"
+#endif
+
 #endif

--- a/include/xwidgets/xwidgets_config_cling.hpp.in
+++ b/include/xwidgets/xwidgets_config_cling.hpp.in
@@ -9,7 +9,19 @@
 #ifndef XWIDGETS_CONFIG_CLING_HPP
 #define XWIDGETS_CONFIG_CLING_HPP
 
+#ifdef __CLING__
+
 #pragma cling add_library_path(@XWIDGETS_INSTALL_LIBRARY_DIR@)
 #pragma cling load("libxwidgets")
 
+#elif defined(__EMSCRIPTEN__) && defined(__CLANG_REPL__)
+
+#include <clang/Interpreter/CppInterOp.h>
+static bool _xwidgets_loaded = []() {
+    Cpp::LoadLibrary("/lib/@CMAKE_SHARED_LIBRARY_PREFIX@xwidgets@CMAKE_SHARED_LIBRARY_SUFFIX@", false);
+    return true;
+}();
+
 #endif
+
+#endif // XWIDGETS_CONFIG_CLING_HPP


### PR DESCRIPTION
We have been using xwidgets in xeus-cpp-lite through a shared build (libxwidgets.so) 

The patch can be found here : https://github.com/emscripten-forge/recipes/pull/2402

This PR upstreams the patch involved and would need a release to get rid of the same on emscripten-forge.